### PR TITLE
Update Couchbase Mobile Travel Sample workshop for 2.7

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -38,23 +38,24 @@ xref:tutorials:customer-360:ingestion.adoc[Retail]
 ==== {empty}
 
 [.summary]
-An in-depth walkthrough of the Couchbase Mobile capabilities on iOS, Android and .NET (UWP and Xamarin) platforms.
+An in-depth walkthrough of the Couchbase Mobile capabilities on iOS, Android, Java (desktop) and .NET (UWP and Xamarin) platforms.
 At the end of this multi-part tutorial, you should have a good understanding of how to architect a solution using Couchbase Mobile, including data modeling, sync, access control, channels, database CRUD and the query API in Couchbase Mobile.
 [.links]
 xref:tutorials:mobile-travel-sample:swift/installation/index.adoc[iOS]
-xref:tutorials:mobile-travel-sample:java/installation/index.adoc[Android]
+xref:tutorials:mobile-travel-sample:android/installation/index.adoc[Android]
+xref:tutorials:mobile-travel-sample:java/installation/index.adoc[Java]
 xref:tutorials:mobile-travel-sample:csharp/installation/index.adoc[.NET]
 
 ===== {empty}
 
 ====== Components
 * Server 6.0.1
-* Lite 2.6
-* Sync Gateway 2.6
+* Lite 2.7
+* Sync Gateway 2.7
 
 ====== Languages
 * Swift
-* Java
+* Java(Android and desktop)
 * C#
 
 [.metadata]


### PR DESCRIPTION
For 2.7 launch, update Travel Sample tutorial to specify 2.7 to include Java