### PR TITLE
Moved Xcode playground tutorial

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -399,6 +399,44 @@ The user Interface is written in JavaScript while the business logic and data mo
 </div>
 ++++
 
+
+[.column]
+[.data-filter-column]
+====== {empty}
+++++
+    <div data-category="beginner swift mobile developer" class="sub-heading two-column-heading">
+        <h3 class="text-color-brand-blue-secondary">Xcode playground for Couchbase Lite Query</h3>
+        <div class="filter-info">
+++++
+pass:attributes[<h5><img src="{url-icon-beginner}" alt="" />Beginner</h5><span>Mobile Developer</span>]
+++++
+        </div>
+    </div>
+++++
+[.content]
+
+A Xcode Playground to explore the Query API in Couchbase Lite 2.x. While the playground demonstrates the queries in swift, given the unified nature of the QueryBuilder API, you should be able to easily translate the queries to any of the other platform languages supported on Couchbase Lite.
+
+++++
+<div class="other-info-list">
+++++
+
+[.box]
+
+* xref:tutorials:swift-playground:overview.adoc[Start Here]
+
+[.box]
+.Component
+* Couchbase Lite 2.8.1
+
+[.box]
+.Languages
+* Swift
+
+++++
+</div>
+++++
+
 [.column]
 [.data-filter-column]
 ====== {empty}
@@ -511,43 +549,6 @@ An comprehensive tutorial that demonstrates how to use Couchbase Server, Spring 
 .Languages
 * Java
 * .NET
-
-++++
-</div>
-++++
-
-[.column]
-[.data-filter-column]
-====== {empty}
-++++
-    <div data-category="beginner swift mobile developer" class="sub-heading two-column-heading">
-        <h3 class="text-color-brand-blue-secondary">Xcode playground for Couchbase Lite Query</h3>
-        <div class="filter-info">
-++++
-pass:attributes[<h5><img src="{url-icon-beginner}" alt="" />Beginner</h5><span>Mobile Developer</span>]
-++++
-        </div>
-    </div>
-++++
-[.content]
-
-A Xcode Playground to demonstrate and explore the Query interface in Couchbase Lite 2.0. While the playground demonstrates the queries in swift, given the unified nature of the QueryBuilder API, you should be able to easily translate the queries to any of the other platform languages supported on Couchbase Lite.
-
-++++
-<div class="other-info-list">
-++++
-
-[.box]
-
-* xref:tutorials:swift-playground:overview.adoc[Start Here]
-
-[.box]
-.Component
-* Couchbase Lite 2.1
-
-[.box]
-.Languages
-* Swift
 
 ++++
 </div>


### PR DESCRIPTION
1) Moved Xcode playground tutorial to before the Android recycler view
2) Slightly tweaked description of Xcode playground tutorial
3) Updated CBL version supported by playground tutorial