### PR TITLE
DOC-7713-C2 

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -24,7 +24,8 @@ include::mobile-travel-sample:partial$nav.adoc[]
 include::cbl-p2p-sync-websockets:partial$nav.adoc[]
 * Xcode Playground
 ** xref:tutorials:swift-playground:overview.adoc[Overview]
-* Recycler Views with Live Queries$nav.adoc[]
+* Recycler Views with Live Queries
+include::university-lister:partial$nav.adoc[]
 * Build a Cordova Plugin
 include::hotel-lister:partial$nav.adoc[]
 * Build a React Native Module

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -21,9 +21,9 @@ include::mobile-travel-sample:partial$nav.adoc[]
 * xref:standalone@userprofile-couchbase-mobile:userprofile:xamarin/userprofile_basic.adoc[Getting Started on Xamarin]
 * xref:standalone@userprofile-couchbase-mobile:userprofile:android/userprofile_basic.adoc[Getting Started on Android]
 // * Getting Started with Peer-to-Peer Sync
-include::cbl-p2p-sync-websockets:partial$nav.adoc[]
-* Xcode Playground
-** xref:tutorials:swift-playground:overview.adoc[Overview]
+include::cbl-p2p-sync-websockets:partial$/nav.adoc[]
+// * Xcode Playground
+* xref:tutorials:swift-playground:overview.adoc[Xcode Playground]
 * Recycler Views with Live Queries
 include::university-lister:partial$nav.adoc[]
 * Build a Cordova Plugin

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -269,10 +269,10 @@ include::partial$p2p-sync-entry-skeleton.adoc[]
 // :param-platform: Android
 // include::partial$p2p-sync-entry-skeleton.adoc[]
 
-// :param-language: C#.Net
-// :param-platform: Xamarin
-// :param-module: csharp
-// include::partial$p2p-sync-entry-skeleton.adoc[]
+:param-language: C#
+:param-platform: Xamarin
+:param-module: dotnet
+include::partial$p2p-sync-entry-skeleton.adoc[]
 
 // END include P2P sync over websocket tutorials - one entry per language/platform
 


### PR DESCRIPTION
DOC-7713-C2 -- Add Getting Started with P2P on Xamarin tutorial code samples 
https://issues.couchbase.com/browse/DOC-7713

Depends on DOC-7713-C1 ( https://github.com/couchbaselabs/couchbase-lite-peer-to-peer-sync-websocket-samples/pull/6)

Comprises 2 commits:
Commit 1 -- Correct nav error introduced in 07d492e, which corrupted the Recycler tutorial link in the nav menu.
Commit 2 (this) -- add C# tutorial to nav and index cards

